### PR TITLE
ID prepass can now toggle between using and not using bounding boxes

### DIFF
--- a/Assets/Scripts/Bounding Boxes Prepass/bboxPrepass.cs
+++ b/Assets/Scripts/Bounding Boxes Prepass/bboxPrepass.cs
@@ -88,6 +88,8 @@ public class bboxPrepass : ScriptableRenderPass
                         // image effects are still tracked separately
                         nprFrameData.presentImageBits |= tag.imageEffects;
 
+                        bbox.renderers.Add(renderer); 
+
                         nprFrameData.bboxes.Add(bbox);
                     }
                 }
@@ -167,6 +169,13 @@ public class bboxPrepass : ScriptableRenderPass
                                     bboxA.testMask &= ~sharedTestEffects;
                                     bboxB.testMask &= ~sharedTestEffects;
 
+                                    mergedBox.renderers.AddRange(bboxA.renderers);
+                                    foreach (var r in bboxB.renderers)
+                                    {
+                                        if (!mergedBox.renderers.Contains(r))
+                                            mergedBox.renderers.Add(r);
+                                    }
+
                                     // add merged box to list
                                     newBoxes.Add(mergedBox); 
 
@@ -244,6 +253,13 @@ public class bboxPrepass : ScriptableRenderPass
                                 // remove shared bits from original boxes
                                 bboxA.styles &= ~sharedEffects;
                                 bboxB.styles &= ~sharedEffects;
+
+                                mergedBox.renderers.AddRange(bboxA.renderers);
+                                foreach (var r in bboxB.renderers)
+                                {
+                                    if (!mergedBox.renderers.Contains(r))
+                                        mergedBox.renderers.Add(r);
+                                }
 
                                 // add merged box to list
                                 newBoxes.Add(mergedBox); 

--- a/Assets/Scripts/Id Prepass/IdPrepass.cs
+++ b/Assets/Scripts/Id Prepass/IdPrepass.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.RenderGraphModule;
 using UnityEngine.Rendering.Universal;
+using System.Collections.Generic;
 
 [System.Serializable]
 public class IdPrepass : ScriptableRenderPass, INprPass
@@ -9,6 +10,7 @@ public class IdPrepass : ScriptableRenderPass, INprPass
     readonly ShaderTagId _shaderTagId = new ShaderTagId("UniversalForward");
     readonly FilteringSettings _filteringSettings;
     readonly Shader _idShader;
+    private readonly Material _idMat;
 
     public bool debugToScreen;
 
@@ -21,6 +23,8 @@ public class IdPrepass : ScriptableRenderPass, INprPass
     {
         public RendererListHandle rendererList;
         public bool debug;
+        public Material mat;
+        public BoundingBox bbox;
     }
 
     const string DebugKeyword = "_DEBUG_ID_COLOUR";
@@ -28,7 +32,10 @@ public class IdPrepass : ScriptableRenderPass, INprPass
     public IdPrepass(Shader idShader)
     {
         _idShader = idShader;
-        renderPassEvent = RenderPassEvent.AfterRenderingOpaques;
+        if (_idShader != null)
+            _idMat = CoreUtils.CreateEngineMaterial(_idShader);
+
+        renderPassEvent = RenderPassEvent.AfterRenderingSkybox;
         _filteringSettings = new FilteringSettings(RenderQueueRange.opaque)
         {
             renderingLayerMask = StyleBits.ImageSpaceBit
@@ -72,46 +79,127 @@ public class IdPrepass : ScriptableRenderPass, INprPass
         });
         nprFrameData.idTexture = idTex;
 
-        // draw objects with id shader
-        DrawingSettings drawing = RenderingUtils.CreateDrawingSettings(_shaderTagId, renderingData, cameraData, lightData, SortingCriteria.CommonOpaque);
-
-        drawing.overrideShader = _idShader;
-        drawing.overrideShaderPassIndex = 0;
-
-        RendererListParams rlp = new RendererListParams(renderingData.cullResults, drawing, _filteringSettings);
-        RendererListHandle rendererList = renderGraph.CreateRendererList(rlp);
-
-        // can't just blit for debugging as the unhashed values are all small and wont show up
-        using (var builder = renderGraph.AddRasterRenderPass("ID Prepass", out PassData passData))
+        // FULLSCREEN MODE (RENDER LAYER MASK AND RENDERLISTHANDLE IS THIS FASTER THAN BBOXES?)
+        if (!NprTestingConfig.UseBoundingBoxes || !NprTestingConfig.IdBoundingBoxes)
         {
-            if (debugToScreen)
-                builder.SetRenderAttachment(frameData.activeColorTexture, 0);
-            else
-                builder.SetRenderAttachment(idTex, 0);
+            // Debug.Log("id prepass NOT using bounding boxes");
+            DrawingSettings drawing = RenderingUtils.CreateDrawingSettings(
+                _shaderTagId,
+                renderingData,
+                cameraData,
+                lightData,
+                SortingCriteria.CommonOpaque
+            );
 
-            builder.SetRenderAttachmentDepth(frameData.activeDepthTexture);
+            drawing.overrideShader = _idShader;
+            drawing.overrideShaderPassIndex = 0;
 
-            builder.UseRendererList(rendererList);
+            RendererListParams rlp = new RendererListParams(
+                renderingData.cullResults,
+                drawing,
+                _filteringSettings
+            );
 
-            // for the global keyword in id shader
-            builder.AllowGlobalStateModification(true);
+            RendererListHandle rendererList = renderGraph.CreateRendererList(rlp);
 
-            passData.rendererList = rendererList;
-            passData.debug = debugToScreen;
-
-            builder.SetRenderFunc(static (PassData data, RasterGraphContext ctx) =>
+            using (var builder = renderGraph.AddRasterRenderPass("Fullscreen ID Prepass", out PassData passData))
             {
-                if (data.debug) 
-                    ctx.cmd.EnableShaderKeyword(DebugKeyword);
-                else            
-                    ctx.cmd.DisableShaderKeyword(DebugKeyword);
+                if (debugToScreen)
+                    builder.SetRenderAttachment(frameData.activeColorTexture, 0);
+                else
+                    builder.SetRenderAttachment(nprFrameData.idTexture, 0);
 
-                ctx.cmd.DrawRendererList(data.rendererList);
+                builder.SetRenderAttachmentDepth(frameData.activeDepthTexture);
+                builder.UseRendererList(rendererList);
+                builder.AllowGlobalStateModification(true);
 
-                // clean up global keyword
-                if (data.debug) 
-                    ctx.cmd.DisableShaderKeyword(DebugKeyword);
-            });
+                passData.rendererList = rendererList;
+                passData.debug = debugToScreen;
+
+                builder.SetRenderFunc(static (PassData data, RasterGraphContext ctx) =>
+                {
+                    if (data.debug)
+                        ctx.cmd.EnableShaderKeyword(DebugKeyword);
+                    else
+                        ctx.cmd.DisableShaderKeyword(DebugKeyword);
+
+                    ctx.cmd.DrawRendererList(data.rendererList);
+
+                    if (data.debug)
+                        ctx.cmd.DisableShaderKeyword(DebugKeyword);
+                });
+            }
+
+            return;
+        }
+        
+
+        // BBOX MODE
+        // Debug.Log("id prepass is using bounding boxes");
+
+        if (nprFrameData.bboxes == null || nprFrameData.bboxes.Count == 0)
+            return;
+
+        foreach (var bbox in nprFrameData.bboxes)
+        {
+            // Debug.Log($"BBox {bbox.box} has {bbox.renderers.Count} renderers");
+
+            if (bbox == null || bbox.box.width <= 0 || bbox.box.height <= 0)
+                continue;
+
+            if (bbox.renderers == null || bbox.renderers.Count == 0)
+                continue;
+
+            using (var builder = renderGraph.AddRasterRenderPass($"BBox ID Prepass ({bbox.box})", out PassData passData))
+            {
+                if (debugToScreen)
+                    builder.SetRenderAttachment(frameData.activeColorTexture, 0, AccessFlags.ReadWrite);
+                else
+                    builder.SetRenderAttachment(nprFrameData.idTexture, 0, AccessFlags.ReadWrite);
+
+                builder.SetRenderAttachmentDepth(frameData.activeDepthTexture);
+                builder.AllowGlobalStateModification(true);
+
+                passData.mat = _idMat;
+                passData.bbox = bbox;
+                passData.debug = debugToScreen;
+
+                builder.SetRenderFunc(static (PassData data, RasterGraphContext ctx) =>
+                {
+                    if (data.debug)
+                        ctx.cmd.EnableShaderKeyword(DebugKeyword);
+                    else
+                        ctx.cmd.DisableShaderKeyword(DebugKeyword);
+
+                    ctx.cmd.EnableScissorRect(new Rect(data.bbox.box.x, data.bbox.box.y, data.bbox.box.width, data.bbox.box.height));
+
+                    List<Renderer> renderers = data.bbox.renderers;
+                    for (int i = 0; i < renderers.Count; i++)
+                    {
+                        // render each renderer in the bbox using the id material
+                        Renderer renderer = renderers[i];
+                        if (renderer == null)
+                            continue;
+
+                        // submesh index is needed for meshes with multiple materials across submeshes
+                        int submeshCount;
+                        if (renderer.sharedMaterials != null)
+                            submeshCount = renderer.sharedMaterials.Length;
+                        else
+                            submeshCount = 1;
+
+                        for (int sub = 0; sub < submeshCount; sub++)
+                        {
+                            ctx.cmd.DrawRenderer(renderer, data.mat, sub, 0);
+                        }
+                    }
+
+                    ctx.cmd.DisableScissorRect();
+
+                    if (data.debug)
+                        ctx.cmd.DisableShaderKeyword(DebugKeyword);
+                });
+            }
         }
     }
 }

--- a/Assets/Scripts/Profiling/TestRunner.cs
+++ b/Assets/Scripts/Profiling/TestRunner.cs
@@ -13,6 +13,10 @@ public static class NprTestingConfig
 {
     public static bool TestMode = false;
     public static bool UseBoundingBoxes = true;
+
+    // ABLATION
+    public static bool IdBoundingBoxes = true; // whether to use bboxes in id prepasss
+
     public static int N = 0; // total styles
     public static int K = 0; // actice styles in scene
     public static int StylesPerObject = 0; // max styles per object
@@ -55,6 +59,8 @@ public class TestRunner : MonoBehaviour
     NprStylesRendererFeature n;
 
     public bool setRendererTestmode = false;
+    public bool setIdPrepassBBoxes = true;
+    public bool setUseBBoxes = true;
     public bool setDebugBBoxes = false;
 
     private string logDir = null;
@@ -250,6 +256,8 @@ public class TestRunner : MonoBehaviour
 
         NprTestingConfig.TestMode = setRendererTestmode;
         NprTestingConfig.debugBBoxes = setDebugBBoxes;
+        NprTestingConfig.IdBoundingBoxes = setIdPrepassBBoxes;
+        NprTestingConfig.UseBoundingBoxes = setUseBBoxes;
         BBoxDebugStore.Clear();
 
         if(NprTestingConfig.TestMode)

--- a/Assets/Scripts/_Pipeline/NprFrameData.cs
+++ b/Assets/Scripts/_Pipeline/NprFrameData.cs
@@ -9,6 +9,7 @@ public class BoundingBox
     public RectInt box;
 
     public uint testMask; // for testing
+    public List<Renderer> renderers = new List<Renderer>();
 
     public BoundingBox(uint s, RectInt b)
     {


### PR DESCRIPTION
Worth testing the performance change as bbox restricted id prepass cannot use RendererListHandle provided by RenderGraph